### PR TITLE
Remove unused netcdf dpi vars from brkfix, clean up compiler errors

### DIFF
--- a/bbb.c
+++ b/bbb.c
@@ -673,12 +673,9 @@ build_global_attr(Exo_DB *p,	/* EXODUS info from representative polylith */
   int e;
   int ebi;
   int ebi_global;
-  int elem_global;		/* 1 ... num_elems in global problem */
-  int elem_global_this_block;	/* since beginning of this block */
   int l;
   int nattr;			/* num element block attributes this block */
   int na;			/* attribute index locally */
-  int na_global;		/* number attribute index globally  */
 
   /*
    * A few checks to throw out nonsense...
@@ -728,10 +725,6 @@ build_global_attr(Exo_DB *p,	/* EXODUS info from representative polylith */
 	   * global perspective.
 	   */
 
-	  elem_global            = d->elem_index_global[e];
-	  elem_global_this_block = elem_global - m->eb_ptr[ebi_global];
-
-	  na_global              = nattr * elem_global_this_block;
 	  na                     = nattr * e;
 	  for ( l=0; l<nattr; l++)
 	    {
@@ -1172,13 +1165,8 @@ mononame(char *in,
   int i;
 
   char in_sans_suffix[FILENAME_MAX_ACK];
-  char suffix[FILENAME_MAX_ACK];
-  char err_msg[1024];
 
   char *p;
-  char *q;
-
-  Spfrtn sr=0;
 
   /*
    * Initialize...
@@ -1187,7 +1175,6 @@ mononame(char *in,
   for ( i=0; i<FILENAME_MAX_ACK; i++)
     {
       in_sans_suffix[i] = '\0';
-      suffix[i]         = '\0';
     }
 
   /*

--- a/brk.c
+++ b/brk.c
@@ -3873,23 +3873,6 @@ main (int argc, char *argv[], char *envp[])
 	  D->ptr_set_membership[i]           = proc_psm[i];
 	}
       
-
-      D->global_node_dof0        = (int *) smalloc(num_universe_nodes*SZ_INT);
-
-      for ( n=0; n<num_universe_nodes; n++)
-	{
-	  node = proc_nodes[n];
-	  D->global_node_dof0[n]  = node_dof0[node];
-	}
-
-      D->global_node_kind         = (int *) smalloc(num_universe_nodes*SZ_INT);
-
-      for ( n=0; n<num_universe_nodes; n++)
-	{
-	  node = proc_nodes[n];
-	  D->global_node_kind[n]  = node_kind[node];
-	}
-
       D->elem_index_global = (int *) smalloc(proc_ne*SZ_INT);
       for ( i=0; i<proc_ne; i++)
 	{
@@ -4663,8 +4646,6 @@ main (int argc, char *argv[], char *envp[])
        *
        *		proc_node_dof0[local_node_number]
        *		global_node_name[local_node_number]
-       *		global_node_dof0[local_node_number]
-       *		global_node_kinds[]
        *		proc_node_kinds[]
        *
        * Obtain a map of the

--- a/dpi.h
+++ b/dpi.h
@@ -104,8 +104,6 @@
 #define VAR_ELEM_ELEM_TWST_GLOBAL		"elem_elem_twst_global"
 #define VAR_ELEM_ELEM_PROC_GLOBAL		"elem_elem_proc_global"
 #define VAR_GLOBAL_NODE_DESCRIPTION		"global_node_description"
-#define VAR_GLOBAL_NODE_DOF0			"global_node_dof0"
-#define VAR_GLOBAL_NODE_KIND			"global_node_kind"
 #define VAR_MY_NAME				"my_name"
 #define VAR_NEIGHBOR				"neighbor"
 #define VAR_NODE_INDEX_GLOBAL			"node_index_global"
@@ -216,8 +214,6 @@ struct Distributed_Processing_Information
 
   int **global_node_description;/* [num_global_node_descriptions]
 				 *                  [len_node_description] */
-  int *global_node_dof0;	/* [num_universe_nodes] */
-  int *global_node_kind;	/* [num_universe_nodes] */
   int my_name;			/* scalar */
   int *neighbor;		/* [num_neighbors] */
   int *node_index_global;	/* New! - [num_nodes_proc] */
@@ -386,8 +382,6 @@ struct Shadow_Identifiers
   int elem_elem_twst_global;
   int elem_elem_proc_global;
   int global_node_description;
-  int global_node_dof0;
-  int global_node_kind;
   int my_name;
   int neighbor;
   int node_index_global;
@@ -460,15 +454,6 @@ struct Shadow_Identifiers
  *				of this variable is typically equal to the
  *				number of element blocks traversed by this
  *				set/proc.
- *
- * len_global_node_dof0		Integer describes the length of the
- *				global_node_dof0[] array. This should be the
- *				number of nodes traversed by this processor,
- *				internal, boundary and external.
- *
- * len_global_node_kind		Integer is the length of the global_node_kind[]
- *				array. Its value should be the number of nodes
- *				known to this processor: (int+bnd+ext).
  *
  * len_node_description		Integer is the length of a node description.
  *				For the current node description structure, the

--- a/exo_conn.c
+++ b/exo_conn.c
@@ -517,8 +517,6 @@ build_elem_elem(Exo_DB *exo)
   int prev_set[MAX_EPN];	/* list of elements attached to previous node*/
   int curr_set[MAX_EPN];	/* list of elements attached to "this" node */
 
-  int interset[MAX_EPN];	/* values of hits between */
-
   int ip[MAX_EPN];		/* indeces of hits for prev_set[] */
   int ic[MAX_EPN];		/* indeces of hits for curr_set[] */
 
@@ -638,7 +636,6 @@ build_elem_elem(Exo_DB *exo)
 	       {
 		 prev_set[i] = -1;
 		 curr_set[i] = -1;
-		 interset[i] = -1;
 	       }
 	     len_prev  = 0;
 	     len_curr  = 0;
@@ -772,7 +769,6 @@ build_elem_elem(Exo_DB *exo)
 
 		 for ( i=0; i<MAX_EPN; i++)
 		   {
-		     interset[i] = -1;
 		     ip[i]       = -1;
 		     ic[i]       = -1;
 		   }
@@ -969,7 +965,6 @@ build_side_node_list(const int elem,
 {
   int i;
   int nodes_this_side;
-  int num_sides;
   int shape;
   
   int local_nodeces[MAX_NODES_PER_SIDE];
@@ -981,7 +976,6 @@ build_side_node_list(const int elem,
    */
 
   shape = get_element_shape(exo, elem);
-  num_sides    = shape2sides(shape);
 
   /*
    * Count up the number of nodes and provide their local 0-based

--- a/fix.c
+++ b/fix.c
@@ -233,7 +233,7 @@ main (int argc, char *argv[], char *envp[])
   int err;
   int i;
   int num_procs=1;		/* from which to build the monolith */
-  int p, pmax, num_node_var_max=0;
+  int p, pmax = 0, num_node_var_max=0;
   int status  = 0;		/* in case anything goes wrong */
   int t;
 

--- a/rd_dpi.c
+++ b/rd_dpi.c
@@ -329,7 +329,7 @@ rd_dpi(Dpi *d,
   int u;			/* short hand for unit... */
 
   struct Shadow_Identifiers si;
-
+  memset(&si, 0, sizeof(struct Shadow_Identifiers));
   status = 0;
 
   for ( i=0; i<NC_MAX_VAR_DIMS; i++)
@@ -552,10 +552,6 @@ rd_dpi(Dpi *d,
 	 &si.elem_var_tab_global);
   getvid(u, VAR_GLOBAL_NODE_DESCRIPTION,   TRUE,
 	 &si.global_node_description);
-  getvid(u, VAR_GLOBAL_NODE_DOF0,          TRUE,
-	 &si.global_node_dof0);
-  getvid(u, VAR_GLOBAL_NODE_KIND,          TRUE,
-	 &si.global_node_kind);
   getvid(u, VAR_MY_NAME,                   TRUE,
 	 &si.my_name);
   getvid(u, VAR_NEIGHBOR,                  FALSE,
@@ -761,12 +757,6 @@ rd_dpi(Dpi *d,
       d->node_index_global = (int *) smalloc(len*sizeof(int));
     }
 
-  if ( d->num_universe_nodes > 0 ) 
-    {
-      d->global_node_dof0 = (int *) smalloc(d->num_universe_nodes*sizeof(int));
-      d->global_node_kind = (int *) smalloc(d->num_universe_nodes*sizeof(int));
-    }
-
   if ( d->num_neighbors > 0 )
     {
       d->neighbor = (int *) smalloc(d->num_neighbors*sizeof(int));
@@ -908,14 +898,6 @@ rd_dpi(Dpi *d,
   get_variable(u, NC_INT, 2, 
 	       d->num_global_node_descriptions,	d->len_node_description, 
 	       si.global_node_description,&(d->global_node_description[0][0]));
-
-  get_variable(u, NC_INT, 1, 
-	       d->num_universe_nodes,	-1, 
-	       si.global_node_dof0,	d->global_node_dof0);
-
-  get_variable(u, NC_INT, 1, 
-	       d->num_universe_nodes,	-1, 
-	       si.global_node_kind,	d->global_node_kind);
 
   get_variable(u, NC_INT, 0, 
 	       -1,	-1, 
@@ -1105,7 +1087,6 @@ getdid(int netcdf_unit,			/* should already be open	(in) */
 {
   int err;
   char err_msg[MAX_CHAR_ERR_MSG];  
-  Spfrtn sr=0;
 
 #ifdef DEBUG
   fprintf(stderr, "getdid(unit=%d, \"%s\", %d, 0x%x\n", netcdf_unit,
@@ -1121,7 +1102,7 @@ getdid(int netcdf_unit,			/* should already be open	(in) */
    */
   if ( err != NC_NOERR && hard_error_interpretation )
     {
-      sr = sprintf(err_msg, "nc_inq_dimid() on %s id=%d", 
+      sprintf(err_msg, "nc_inq_dimid() on %s id=%d", 
 		   string_name, 
 		   *dimension_identifier_address);
       EH(-1, err_msg);
@@ -1132,9 +1113,8 @@ getdid(int netcdf_unit,			/* should already be open	(in) */
   err  = ncdimid(netcdf_unit, string_name);
   if ( err == -1 && hard_error_interpretation )
     {
-      sr   = sprintf(err_msg, "ncdimid() on %s rtn %d", string_name, err);
+      sprintf(err_msg, "ncdimid() on %s rtn %d", string_name, err);
       EH(err, err_msg);
-      EH(sr, err_msg);
     }
   *dimension_identifier_address = err;
 #endif  
@@ -1173,7 +1153,6 @@ getvid(int netcdf_unit,		         /* open netCDF unit identifier (in) */
 {
   int err;
   char err_msg[MAX_CHAR_ERR_MSG];  
-  Spfrtn sr=0;
 
 
 #ifdef NETCDF_3
@@ -1181,7 +1160,7 @@ getvid(int netcdf_unit,		         /* open netCDF unit identifier (in) */
   err  = nc_inq_varid(netcdf_unit, string_name, variable_identifier_address);
   if ( err != NC_NOERR && hard_error_interpretation )
     {
-      sr = sprintf(err_msg, "nc_inq_varid() on %s id=%d", 
+      sprintf(err_msg, "nc_inq_varid() on %s id=%d", 
 		   string_name, 
 		   *variable_identifier_address);
       EH(-1, err_msg);
@@ -1192,9 +1171,8 @@ getvid(int netcdf_unit,		         /* open netCDF unit identifier (in) */
   err  = ncvarid(netcdf_unit, string_name);
   if ( err == -1 && hard_error_interpretation )
     {
-      sr   = sprintf(err_msg, "ncvarid() on %s rtn %d", string_name, err);
+      sprintf(err_msg, "ncvarid() on %s rtn %d", string_name, err);
       EH(err, err_msg);
-      EH(sr, err_msg);
     }
   *variable_identifier_address = err;
 #endif  
@@ -1225,7 +1203,6 @@ getdim(int netcdf_unit,
 {
   int err;
   char err_msg[MAX_CHAR_ERR_MSG];  
-  Spfrtn sr=0;
 #ifdef NETCDF_3
   size_t swhere;
 #endif
@@ -1250,7 +1227,7 @@ getdim(int netcdf_unit,
       err  = nc_inq_dimlen(netcdf_unit, dimension_id, &swhere);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_inq_dimlen() on did=%d", dimension_id);
+	  sprintf(err_msg, "nc_inq_dimlen() on did=%d", dimension_id);
 	  EH(-1, err_msg);
 	}
       *where = (int) swhere;
@@ -1258,11 +1235,10 @@ getdim(int netcdf_unit,
 
 #ifdef NETCDF_2
       err  = ncdiminq(netcdf_unit, dimension_id, junk, &swhere);
-      sr   = sprintf(err_msg, "ncdiminq() on did %d rtns %d", dimension_id, 
+      sprintf(err_msg, "ncdiminq() on did %d rtns %d", dimension_id, 
 		     err);
       *where = (int) swhere;
       EH(err, err_msg);
-      EH(sr, err_msg);
 #endif  
     }
   return;
@@ -1363,8 +1339,6 @@ uni_dpi(Dpi *dpi,
 	}
     }
   
-  dpi->global_node_dof0        = First_Unknown;
-
   /*
    * Well, yes, this looks fishy. To avoid wasting memory, just point this
    * to some array with a length that is the number of nodes in the problem
@@ -1372,8 +1346,6 @@ uni_dpi(Dpi *dpi,
    * serial problems. If and when you really make use of it, then go ahead
    * and allocate space to hold the proper integer labels.
    */
-
-  dpi->global_node_kind        = First_Unknown;
 
   dpi->neighbor                = &ProcID;
 
@@ -1468,8 +1440,6 @@ free_dpi(Dpi *d)
   safe_free(d->global_node_description[0]);
   safe_free(d->global_node_description);
 
-  safe_free(d->global_node_dof0);
-  safe_free(d->global_node_kind);
   safe_free(d->neighbor);
 
   if ( d->num_nodes > 0 )
@@ -1608,7 +1578,6 @@ get_variable(const int netcdf_unit,
   long start[NC_MAX_VAR_DIMS];
 #endif
   char err_msg[MAX_CHAR_ERR_MSG];
-  Spfrtn sr=0;
 
   get_variable_call_count++;
 
@@ -1629,7 +1598,7 @@ get_variable(const int netcdf_unit,
       err = nc_get_var_int(netcdf_unit, variable_identifier, variable_address);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_get_var_int() varid=%d", 
+	  sprintf(err_msg, "nc_get_var_int() varid=%d", 
 		       variable_identifier);
 	  EH(-1, err_msg);
 	}
@@ -1640,7 +1609,7 @@ get_variable(const int netcdf_unit,
 			    variable_address);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_get_var_text() varid=%d", 
+	  sprintf(err_msg, "nc_get_var_text() varid=%d", 
 		       variable_identifier);
 	  EH(-1, err_msg);
 	}
@@ -1651,7 +1620,7 @@ get_variable(const int netcdf_unit,
 			      variable_address);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_get_var_double() varid=%d", 
+	  sprintf(err_msg, "nc_get_var_double() varid=%d", 
 		       variable_identifier);
 	  EH(-1, err_msg);
 	}
@@ -1667,10 +1636,9 @@ get_variable(const int netcdf_unit,
   
   if ( num_dimensions < 0 || num_dimensions > 2 )
     {
-      sr = sprintf(err_msg, "Bad or too large dimension value %d", 
+      sprintf(err_msg, "Bad or too large dimension value %d", 
 		   num_dimensions);
       EH(-1, err_msg);
-      EH(sr, err_msg);
     }
 
   for ( i=0; i<num_dimensions; i++)
@@ -1701,7 +1669,7 @@ get_variable(const int netcdf_unit,
 		 variable_address);
   if ( err < 0 )
     {
-      sr = sprintf(err_msg, 
+      sprintf(err_msg, 
 		   "get_variable (%d call), varid %d (%d dim %d,%d)\n",
 		   get_variable_call_count,
 		   variable_identifier, num_dimensions, 

--- a/rd_exo.c
+++ b/rd_exo.c
@@ -262,7 +262,7 @@ rd_exo(Exo_DB *x,		/* def'd in exo_struct.h */
 
 	  for ( i=0; i<x->num_info; i++)
 	    {
-	      x->info[i] = (char *) smalloc(MAX_LINE_LENGTH * sc);
+	      x->info[i] = (char *) smalloc((MAX_LINE_LENGTH+1) * sc);
 	    }
 	  status = ex_get_info(x->exoid, &(x->info[0]));
 	  EH(status, "ex_get_info");

--- a/utils.c
+++ b/utils.c
@@ -683,7 +683,7 @@ get_filename_num_procs(const char *basename)
   }
 
   sprintf(string_system_command, 
-          "ls -1t %s.exoII.*.1 | head -1 | sed -e 's/^.*\.exoII\.//' -e 's/\.1//'  > %s",
+          "ls -1t %s.exoII.*.1 | head -1 | sed -e 's/^.*\\.exoII\\.//' -e 's/\\.1//'  > %s",
 	  basename, fixXXXXXX );
 
   if ( -1 == system(string_system_command) )

--- a/wr_dpi.c
+++ b/wr_dpi.c
@@ -414,16 +414,6 @@ wr_dpi(Dpi *d,
 		  d->num_global_node_descriptions, d->len_node_description,
 		  &si.global_node_description);
 
-  define_variable(u, VAR_GLOBAL_NODE_DOF0, NC_INT, 1, 
-		  si.num_universe_nodes, -1,
-		  d->num_universe_nodes, -1,
-		  &si.global_node_dof0);
-
-  define_variable(u, VAR_GLOBAL_NODE_KIND, NC_INT, 1, 
-		  si.num_universe_nodes, -1,
-		  d->num_universe_nodes, -1,
-		  &si.global_node_kind);
-
   define_variable(u, VAR_MY_NAME, NC_INT, 0, 
 		  -1, -1,
 		  -1, -1,
@@ -704,14 +694,6 @@ wr_dpi(Dpi *d,
 	       d->num_global_node_descriptions,	d->len_node_description, 
 	       si.global_node_description,&(d->global_node_description[0][0]));
 
-  put_variable(u, NC_INT, 1, 
-	       d->num_universe_nodes,	-1, 
-	       si.global_node_dof0,	d->global_node_dof0);
-
-  put_variable(u, NC_INT, 1, 
-	       d->num_universe_nodes,	-1, 
-	       si.global_node_kind,	d->global_node_kind);
-
   put_variable(u, NC_INT, 0, 
 	       -1,	-1, 
 	       si.my_name,		&(d->my_name));
@@ -907,7 +889,6 @@ define_dimension(const int unit,
 {
   int err;
   char err_msg[MAX_CHAR_ERR_MSG];
-  Spfrtn sr=0;
 
   /*
    * Dimensions with value zero are problematic, so filter them out.
@@ -922,17 +903,16 @@ define_dimension(const int unit,
   err  = nc_def_dim(unit, string, value, identifier);
   if ( err != NC_NOERR )
     {
-      sr = sprintf(err_msg, "nc_def_dim() on %s [<%d] id=%d", string, 
+      sprintf(err_msg, "nc_def_dim() on %s [<%d] id=%d", string, 
 		   value, *identifier);
       EH(-1, err_msg);
     }
 #endif
 #ifdef NETCDF_2
   err  = ncdimdef(unit, string, value);
-  sr   = sprintf(err_msg, "ncdimdef() on %s [<%d] rtn %d", string, 
+  sprintf(err_msg, "ncdimdef() on %s [<%d] rtn %d", string, 
 		 value, err);
   EH(err, err_msg);
-  EH(sr, err_msg);
   *identifier = err;
 #endif  
 
@@ -966,7 +946,6 @@ define_variable(const int netcdf_unit,
 {			    
   int err;
   char err_msg[MAX_CHAR_ERR_MSG];
-  Spfrtn sr=0;
 
 #ifdef NETCDF_3
   int dim[NC_MAX_VAR_DIMS];
@@ -987,7 +966,7 @@ define_variable(const int netcdf_unit,
 	{
 	  return;		/* Do not even create a variable. */
 	  /*
-	  sr = sprintf(err_msg, "Bad 1st netCDF dimension ID %d for %s\n",
+	  sprintf(err_msg, "Bad 1st netCDF dimension ID %d for %s\n",
 		       dimension_id_1, name_string);
 	  EH(-1, err_msg);
 	  */
@@ -1002,10 +981,9 @@ define_variable(const int netcdf_unit,
     {
       if ( dimension_id_2 < 0 )
 	{
-	  sr = sprintf(err_msg, "Bad 2nd netCDF dimension ID %d for %s\n",
+	  sprintf(err_msg, "Bad 2nd netCDF dimension ID %d for %s\n",
 		       dimension_id_1, name_string);
 	  EH(-1, err_msg);
-	  EH(sr, err_msg);
 	}
       if ( dimension_val_2 < 1 )
 	{
@@ -1021,7 +999,7 @@ define_variable(const int netcdf_unit,
 		      dim, identifier);
   if ( err != NC_NOERR )
     {
-      sr = sprintf(err_msg, "nc_def_var on %s (%d-D) id=%d", name_string, 
+      sprintf(err_msg, "nc_def_var on %s (%d-D) id=%d", name_string, 
 		   num_dimensions, *identifier);
       EH(-1, err_msg);
     }
@@ -1034,7 +1012,7 @@ define_variable(const int netcdf_unit,
 
   err    = ncvardef(netcdf_unit, name_string, netcdf_type, num_dimensions, 
 		    tim);
-  sr     = sprintf(err_msg, "ncvardef on %s (%d-D) id=%d", name_string, 
+  sprintf(err_msg, "ncvardef on %s (%d-D) id=%d", name_string, 
 		   num_dimensions, err);
   EH(err, err_msg);
   *identifier   = err;
@@ -1054,7 +1032,6 @@ put_variable(const int netcdf_unit,
 {
   int err;
   char err_msg[MAX_CHAR_ERR_MSG];
-  Spfrtn sr=0;
 
   /*
    * If a variable was really defined properly and doesn't have a valid
@@ -1073,7 +1050,7 @@ put_variable(const int netcdf_unit,
       err = nc_put_var_int(netcdf_unit, variable_identifier, variable_address);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_put_var_int() varid=%d", 
+	  sprintf(err_msg, "nc_put_var_int() varid=%d", 
 		       variable_identifier);
 	  EH(-1, err_msg);
 	}
@@ -1084,7 +1061,7 @@ put_variable(const int netcdf_unit,
 			    variable_address);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_put_var_text() varid=%d", 
+	  sprintf(err_msg, "nc_put_var_text() varid=%d", 
 		       variable_identifier);
 	  EH(-1, err_msg);
 	}
@@ -1095,7 +1072,7 @@ put_variable(const int netcdf_unit,
 			      variable_address);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_put_var_double() varid=%d", 
+	  sprintf(err_msg, "nc_put_var_double() varid=%d", 
 		       variable_identifier);
 	  EH(-1, err_msg);
 	}
@@ -1111,10 +1088,9 @@ put_variable(const int netcdf_unit,
   
   if ( num_dimensions < 0 || num_dimensions > 2 )
     {
-      sr = sprintf(err_msg, "Bad or too large dimension value %d", 
+      sprintf(err_msg, "Bad or too large dimension value %d", 
 		   num_dimensions);
       EH(-1, err_msg);
-      EH(sr, err_msg);
     }
 
   for ( i=0; i<num_dimensions; i++)
@@ -1133,7 +1109,7 @@ put_variable(const int netcdf_unit,
 	   */
 	  return;
 	  /*
-	  sr = sprintf(err_msg, 
+	  sprintf(err_msg, 
 	  "Data type %s (%d dimensional) has dimension values = %d %d",
 		       string_type(netcdf_type), num_dimensions, 
 		       dimension_val_1, dimension_val_2);
@@ -1155,7 +1131,7 @@ put_variable(const int netcdf_unit,
 	   */
 	  return;
 	  /*
-	  sr = sprintf(err_msg, 
+	  sprintf(err_msg, 
 	  "Data type %s (%d dimensional) has dimension values = %d %d",
 		       string_type(netcdf_type), num_dimensions, 
 		       dimension_val_1, dimension_val_2);


### PR DESCRIPTION
Removes global_node_dof0 and global_node_kind from distributed processing information, also cleans up compiler warnings.

Go's with goma/goma#47
