### PR TITLE
Support global exodus variables in brk and fix

### DIFF
--- a/Makefile.Trilinos
+++ b/Makefile.Trilinos
@@ -29,7 +29,7 @@
 
             GOMA_LIBS = /home/goma/production
 
-            TRILINOS_TOP ?= $(GOMA_LIBS)/trilinos-12.2.1-Built
+            TRILINOS_TOP ?= $(GOMA_LIBS)/trilinos-12.6.3-Built
 
             include $(TRILINOS_TOP)/include/Makefile.export.Trilinos
 

--- a/fix.c
+++ b/fix.c
@@ -753,6 +753,41 @@ main (int argc, char *argv[], char *envp[])
 	      t, mono->nv_time_indeces[0]);
 #endif
       wr_result_exo(mono, monolith_file_name, 0);
+
+      if ( mono->num_glob_vars > 0 ) {
+
+	mono->cmode = EX_WRITE;
+
+
+	mono->io_wordsize   = 0;	/* i.e., query */
+	mono->comp_wordsize = sizeof(dbl);
+	mono->exoid         = ex_open(mono->path, 
+				   mono->cmode, 
+				   &mono->comp_wordsize, 
+				   &mono->io_wordsize, 
+				   &mono->version);
+
+	/*status = ex_put_var_param(mono->exoid, "g", mono->num_glob_vars);
+	EH(status, "ex_put_var_param(g)");
+	*/
+	status = ex_put_var_names(mono->exoid, "g", mono->num_glob_vars,
+				  mono->glob_var_names);
+	EH(status, "ex_put_var_names(g)");
+
+
+
+	for (i = 0; i < mono->num_gv_time_indeces; i++) {
+	  status = ex_put_glob_vars(mono->exoid, mono->gv_time_indeces[i],
+			   mono->num_glob_vars,
+			   mono->gv[i]);
+	  EH(status, "ex_put_glob_vars");
+	}
+
+	status = ex_close(mono->exoid);
+	EH(status, "ex_close()");
+
+      }
+
       zero_base(mono);
     }
 

--- a/rd_exo.c
+++ b/rd_exo.c
@@ -998,13 +998,13 @@ rd_exo(Exo_DB *x,		/* def'd in exo_struct.h */
        * setup and reasonable.
        */
 
-      if ( x->num_gv_time_indeces > 0 &&
+      if ( x->num_times > 0 &&
 	   x->num_glob_vars > 0 )
 	{
 
 	  if ( ! ( x->state & EXODB_STATE_GBVA ) )
 	    {
-	      alloc_exo_gv(x, 1);
+	      alloc_exo_gv(x, x->num_times);
 	    }
 
 	  for ( i=0; i<x->num_gv_time_indeces; i++)
@@ -2543,7 +2543,7 @@ alloc_exo_gv(Exo_DB *x,
    * Fill these indeces with reasonable defaults.
    */
 
-  for ( i=0; i<x->num_nv_time_indeces; i++)
+  for ( i=0; i<x->num_gv_time_indeces; i++)
     {
       x->gv_time_indeces[i] = i+1;
     }


### PR DESCRIPTION
Brk and fix should now write and read global variables from exodus files (such as NEWT_IT and those for augmenting conditions)